### PR TITLE
fix: missing include crc.h in wear.c

### DIFF
--- a/src/wear.c
+++ b/src/wear.c
@@ -1,5 +1,6 @@
 #include "wear.h"
 #include "core.h"
+#include "crc.h"
 #include <stdint.h>
 
 /** @brief Wear handling enum */ 


### PR DESCRIPTION
`wear.c` references `crc_file_check` and `crc_header_check` which are defined in `crc.h` but it is never included, which causes a build error in the test example.