### PR TITLE
fix: multiple instances of sign comparison warnings

### DIFF
--- a/include/storfs.h
+++ b/include/storfs.h
@@ -374,7 +374,7 @@ storfs_err_t storfs_fopen(storfs_t *storfsInst, char *pathToFile, const char * m
  * @param       stream      File to write to
  * @return      STORFS_OK   Succeed
  */
-storfs_err_t storfs_fputs(storfs_t *storfsInst, const char *str, const int n, STORFS_FILE *stream);
+storfs_err_t storfs_fputs(storfs_t *storfsInst, const char *str, const storfs_size_t n, STORFS_FILE *stream);
 
 /**
  * @brief       fgets

--- a/src/fgets.c
+++ b/src/fgets.c
@@ -21,7 +21,7 @@ storfs_err_t storfs_fgets(storfs_t *storfsInst, char *str, int n, STORFS_FILE *s
     uint32_t recvDataLen;                                       //Current length to read from file
     storfs_file_header_t currHeaderInfo;                        //Info of the current in the file
     uint32_t headerLen = STORFS_HEADER_TOTAL_SIZE;              //Fragment or file header length
-    int count = n;                                              //Storage for total number of bytes to be read from the file
+    storfs_size_t count = n;                                              //Storage for total number of bytes to be read from the file
     storfs_loc_t recvDataHeaderLoc;                             //The location of the current file header in memory
     
     recvDataHeaderLoc.pageLoc = stream->fileRead.readLocPtr.pageLoc;
@@ -30,7 +30,7 @@ storfs_err_t storfs_fgets(storfs_t *storfsInst, char *str, int n, STORFS_FILE *s
     file_header_store_helper(storfsInst, &currHeaderInfo, recvDataHeaderLoc, "fgets");
     
     //Determine the number of iterations needed to read from the file
-    if(count < stream->fileRead.fileSizeRem)
+    if(count < (storfs_size_t)stream->fileRead.fileSizeRem)
     {
         if(count > storfsInst->pageSize)
         {

--- a/src/fputs.c
+++ b/src/fputs.c
@@ -3,7 +3,7 @@
 #include "crc.h"
 #include "core.h"
 
-storfs_err_t storfs_fputs(storfs_t *storfsInst, const char *str, const int n, STORFS_FILE *stream)
+storfs_err_t storfs_fputs(storfs_t *storfsInst, const char *str, const storfs_size_t n, STORFS_FILE *stream)
 {
     //Sanity Check
     if(!storfsInst || !stream || !str || !stream)
@@ -34,7 +34,7 @@ storfs_err_t storfs_fputs(storfs_t *storfsInst, const char *str, const int n, ST
     uint8_t sendBuf[storfsInst->pageSize];                                    //Buffer of data to send to flash device                                      
     uint8_t headerBuf[STORFS_HEADER_TOTAL_SIZE];                              //Buffer used to store the header of each page
     uint32_t headerLen = STORFS_HEADER_TOTAL_SIZE;                            //Length of header to be used depending on fragment header or file header
-    int count = n;                                                            //Length of the data to be placed in storage
+    storfs_size_t count = n;                                                            //Length of the data to be placed in storage
     int32_t sendDataItr = 0;                                                  //Iterations for the number of pages to be programmed
     int32_t currItr = 0;
 
@@ -246,10 +246,10 @@ storfs_err_t storfs_fputs(storfs_t *storfsInst, const char *str, const int n, ST
 
         //Convert the current header info into a buffer and store it in the first bytes to be programmed
         //Store the data to be programmed as well in the buffer
-        for(int i = headerLen; i < wearLevelInfo.sendDataLen; i++)
+        for(storfs_size_t i = headerLen; i < wearLevelInfo.sendDataLen; i++)
         {
             //If there is items to append to the current buffer
-            if(currItr == 0 && ((i - headerLen) < appendHeaderByteLoc))
+            if(currItr == 0 && ((i - headerLen) < (storfs_size_t)appendHeaderByteLoc))
             {
                 continue;
             }
@@ -264,7 +264,7 @@ storfs_err_t storfs_fputs(storfs_t *storfsInst, const char *str, const int n, ST
 
         //Place Header into buffer
         info_to_buf(headerBuf, &currHeaderInfo);
-        for(int i = 0; i < headerLen; i++)
+        for(storfs_size_t i = 0; i < headerLen; i++)
         {
             sendBuf[i] = headerBuf[i];
         }

--- a/src/mount.c
+++ b/src/mount.c
@@ -9,7 +9,7 @@ storfs_err_t storfs_mount(storfs_t *storfsInst, char *partName)
     }
 
     storfs_file_header_t firstPartInfo[2];
-    uint32_t strLen = 0;
+    storfs_size_t strLen = 0;
 
     STORFS_LOGI(TAG, "Mounting File System");
 
@@ -61,7 +61,7 @@ storfs_err_t storfs_mount(storfs_t *storfsInst, char *partName)
         }
 
         //Store file parameters
-        for(int i = 0; i < strLen; i++)
+        for(storfs_size_t i = 0; i < strLen; i++)
         {
             firstPartInfo[0].fileName[i] = partName[i];
         }

--- a/src/rm.c
+++ b/src/rm.c
@@ -155,7 +155,7 @@ storfs_err_t storfs_rm(storfs_t *storfsInst, char *pathToFile, STORFS_FILE *stre
             }
 
             info_to_buf(updatedHeader, &storfsPreviousHeader);
-            for(int i = 0; i < storfsInst->pageSize; i++)
+            for(storfs_size_t i = 0; i < storfsInst->pageSize; i++)
             {
                 if(i < STORFS_HEADER_TOTAL_SIZE)
                 {


### PR DESCRIPTION
Compiling with `-Wall -Wextra` produces a lot of sign comparison warnings, this patch fixes most of the warnings.