### PR TITLE
feat/ci: Add format, build and test ci actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,15 @@
+name: Build and Test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run make
+      run: cd test && make

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,45 @@
+name: ClangFormat Check
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt update
+          sudo apt install -y clang-format
+
+      - name: Check formatting
+        run: |
+          FILES=$(git ls-files '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx')
+
+          if [ -z "$FILES" ]; then
+            echo "No file(s) were found"
+            exit 0
+          fi
+
+          UNFORMATTED=""
+
+          for f in $FILES; do
+            if ! clang-format --dry-run --Werror "$f" >/dev/null 2>&1; then
+              UNFORMATTED="$UNFORMATTED\n$f"
+            fi
+          done
+
+          if [ -n "$UNFORMATTED" ]; then
+            echo "The following files are not properly formatted:"
+            echo -e "$UNFORMATTED"
+            exit 1
+          fi
+
+          echo "All files are properly formatted"
+          exit 0

--- a/test/Makefile
+++ b/test/Makefile
@@ -10,4 +10,4 @@ init:
 	@docker build -t storfs .
 
 test: init
-	@docker run --rm -ti -v "./../":"/storfs" storfs -t $(Arguments)
+	@docker run --rm -i -v "./../":"/storfs" storfs -t $(Arguments)


### PR DESCRIPTION
This adds two github ci actions

1. Formatting via clang format
I initially planned to use https://github.com/jidicula/clang-format-action but no matter what i did, it simply just didnt work for me. I am assuming it has to do something with: https://github.com/jidicula/clang-format-action/issues/267
So instead I just wrote the part manually in shell script

2. Build and test via docker
Github actions do not support TTY for docker run, so had to remove the -t flag from `docker run ...` in test Makefile

closes #21 